### PR TITLE
bugfix: upgrade to regexparam 2.0.0

### DIFF
--- a/src/utils/regexparam.js
+++ b/src/utils/regexparam.js
@@ -1,4 +1,4 @@
-export { default as regexparam } from '../deps/regexparam.js';
+export { parse as regexparam } from '../deps/regexparam.js';
 export function exec(url, pathObject) {
   let i = 0,
     out = {};


### PR DESCRIPTION
The latest release of https://github.com/lukeed/regexparam named the
default export parse. This change brings this codebase back to parity
from before this breaking change was introduced.